### PR TITLE
Updated Coalition AppSec Security Workflow (RUN-001)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,24 @@
+---
+# This calls a shared security workflow which dynamically assesses code security.
+# This workflow is owned by the Coalition AppSec Team;
+# Confluence: https://fiasco.atlassian.net/wiki/spaces/ENG/pages/2876080164/Static+Analysis+Tooling+Integration
+# YAML Documentation: https://github.com/crucible-risk/github-workflows/
+# If there are failures, questions, or issues, please reach out in #help-appsec.
+
+name: "AppSec"
+
+on:
+  push:
+    branches: 
+    - main
+    - master
+    - dev
+  workflow_dispatch:
+
+jobs:
+  analyze_security:
+    uses: crucible-risk/github-workflows/.github/workflows/security_analyze.yml@master
+    secrets:
+      github_pat: ${{ secrets.DEPLOY_USER_PAT }}
+
+#APPSEC_WF:RUN-001


### PR DESCRIPTION
This PR adds support for a centralized security workflow which runs on changes to `master`, `main`, and/or `dev`. This helps to track this repository’s security posture, and integrates into Coalition’s centralized security dashboard.

This workflow will run in parallel to any builds and **will not block** releases or development, even if an error occurs.

This workflow centralizes the execution of CodeQL to minimize future impact to engineering teams when keeping rules up to date.

The AppSec team will be responsible for maintaining this workflow if there are any security issues in the future. If there are questions, please reach out to the team in our Slack channel, #help-appsec.

More information can be found in Confluence at https://fiasco.atlassian.net/wiki/spaces/ENG/pages/2876080164/Static+Analysis+Tooling+Integration